### PR TITLE
Cleanly handle cancelling

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -43,7 +43,7 @@ main() {
   items=$(get_bw_items "${TMUX_OPTS[@bw-session]}")
 
   # Choice element
-  key=$(echo "$items" | jq --raw-output '.|keys[]' | fzf --no-multi)
+  key=$(echo "$items" | jq --raw-output '.|keys[]' | fzf --no-multi) || return
 
   password=$(get_password "$items" "$key")
 


### PR DESCRIPTION
Currently if the script is interrupted/cancelled during `fzf` it will send "ul" to the pane.

This seems to be because the command substitution `$(..)` is interrupted rather than the script it self. Meaning the `password` variable is empty, and then the `get_password` function returns `null`, which becomes `ul` after the substring is applied

### Proposed solution
- Add `|| return`so that the script will terminate if `fzf` has a non-zero return code