### PR TITLE
Tidying up Shellcheck warnings and silencing config option checks

### DIFF
--- a/plugin.tmux
+++ b/plugin.tmux
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-declare -r CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+declare -r CURRENT_DIR
 
-# shellcheck source=utils.sh
+# shellcheck source=/dev/null
 source "$CURRENT_DIR/scripts/utils.sh"
 
 declare -a REQUIRED_BINARIES=(

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+#cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+declare -r CURRENT_DIR
 
-source "./utils.sh"
+# shellcheck source=/dev/null
+source "$CURRENT_DIR/utils.sh"
 
 is_authenticated() {
   [[ $(bw status | jq '.status') != "\"unauthenticated\"" ]] && true
@@ -30,7 +33,7 @@ get_password() {
 
 main() {
   declare -A TMUX_OPTS=(
-    ["@bw-session"]=$(get_tmux_option "@bw-session" $BW_SESSION)
+    ["@bw-session"]=$(get_tmux_option "@bw-session" "$BW_SESSION")
     ["@bw-copy-to-clipboard"]=$(get_tmux_option "@bw-copy-to-clipboard" "off")
   )
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-#cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 declare -r CURRENT_DIR
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -27,7 +27,8 @@ is_binary_exist() {
 get_tmux_option() {
   local option="$1"
   local default_value="$2"
-  local option_value=$(tmux show-option -gv "$option")
+  local option_value
+  option_value=$(tmux show-option -gqv "$option")
 
   if [[ -z "$option_value" ]]; then
     echo "$default_value"


### PR DESCRIPTION
Mostly nitpick shellcheck things, but the `tmux show-option` printing an `invalid option` warning for every unset variable was driving me insane, so `-q` was added to the call to silence the output.